### PR TITLE
Fix extension bug when loading XML

### DIFF
--- a/flixel/addons/ui/FlxUIState.hx
+++ b/flixel/addons/ui/FlxUIState.hx
@@ -69,7 +69,7 @@ class FlxUIState extends FlxState implements IEventGetter implements IFlxUIState
 			
 			var data:Fast = U.xml(_xml_id);
 			if (data == null) {
-				data = U.xml(_xml_id, ".xml", true, "");	//try again without default directory prepend
+				data = U.xml(_xml_id, "xml", true, "");	//try again without default directory prepend
 			}
 			
 			if (data == null) {


### PR DESCRIPTION
This corrects a small bug that severely impacts loading XML from a non-standard path.

The `U.xml` function starts like this:

``` haxe
public static function xml(id:String, extension:String = "xml",getFast:Bool=true,dir="assets/xml/"):Dynamic {
  var str:String = Assets.getText(dir + id + "." + extension);
```

As you can see, it takes an extension without a period (as it adds it in the first line). Ergo, the call that's corrected in this PR results in this problem in the current version:

```
Assets.hx:526: [openfl.Assets] There is no String asset with an ID of "assets/xml/data/gui/main_menu.xml"
Assets.hx:526: [openfl.Assets] There is no String asset with an ID of "data/gui/main_menu..xml"
```

Double periods!
