### PR TITLE
Small fix regarding center_on_x and center_on_y

### DIFF
--- a/flixel/addons/ui/FlxUI.hx
+++ b/flixel/addons/ui/FlxUI.hx
@@ -2988,13 +2988,13 @@ class FlxUI extends FlxUIGroup implements IEventGetter
 			}
 		}else {
 			if (center_on_x != "") {
-				var other = getAsset(center_on);
+				var other = getAsset(center_on_x);
 				if (other != null) {
 					U.center(cast(other, FlxObject), cast(thing, FlxObject), true, false);
 				}
 			}
 			if (center_on_y != "") {
-				var other = getAsset(center_on);
+				var other = getAsset(center_on_y);
 				if (other != null) {
 					U.center(cast(other, FlxObject), cast(thing, FlxObject), false, true);
 				}


### PR DESCRIPTION
center_on_x and center_on_y in FlxUI do not work. If you specify one of them, the code tries to get the asset from center_on instead. But, if you specify center_on, center_on_x/center_on_y are ignored.
