### PR TITLE
Set the id of widgets after loading them from the xml

### DIFF
--- a/flixel/addons/ui/FlxUI.hx
+++ b/flixel/addons/ui/FlxUI.hx
@@ -550,6 +550,9 @@ class FlxUI extends FlxUIGroup implements IEventGetter
 						
 						if (thing_id != null && thing_id != "") {
 							_asset_index.set(thing_id, thing);
+							
+							//The widget id can be used in getEvent-handlers.
+							thing.id = thing_id;
 						}
 					}
 				}


### PR DESCRIPTION
This change is small but useful. This pull will set the id of widgets after loading them from the xml, if the id was specified in there. It's not really useful to have a null-id, if the id was not-null in the xml.

This allows us to use the id in a getEvent-handler of a FlxUIState. For example, different actions for multiple buttons can be handled without adding a param-tag by just setting the id.

I'm proposing this, because managing param-Tags seems unnecessary in busy layouts. Maybe I'm missing something?
