### PR TITLE
Added ability to use FlxColors for color attributes

### DIFF
--- a/flixel/addons/ui/U.hx
+++ b/flixel/addons/ui/U.hx
@@ -348,9 +348,12 @@ class U
 	
 	public static inline function parseHex(str:String,cast32Bit:Bool=false,safe:Bool=false,default_color:Int=0x000000):Int {
 		var return_val = FlxColor.fromString(str);
-		if(return_val == null)
-		{
-			throw "U.parseHex() unable to parse hex String " + str;
+		if(return_val == null) {
+			if(!safe) {
+				throw "U.parseHex() unable to parse hex String " + str;
+			}else {
+				return_val = default_color;	
+			}
 		}	
 		return return_val;
 	}


### PR DESCRIPTION
For: https://github.com/HaxeFlixel/flixel-ui/issues/43

Uses reflection (sorry larsiusprime, haven't learned how to use haXe macros yet) to attempt resolution of a color first. If not, it'll resort to trying hex values using the existing methods. 
Also, it only handles upper-case colors. Would be easy to have it handle lower-case as well if desired. 
