### PR TITLE
Fix for destroying dropdowns

### DIFF
--- a/flixel/addons/ui/FlxUIDropDownMenu.hx
+++ b/flixel/addons/ui/FlxUIDropDownMenu.hx
@@ -347,12 +347,7 @@ class FlxUIDropDownMenu extends FlxUIGroup implements IFlxUIWidget implements IF
 		
 		dropPanel = FlxDestroyUtil.destroy(dropPanel);
 		
-		for (button in list)
-		{
-			button = FlxDestroyUtil.destroy(button);
-		}
-		
-		list = null;
+		list = FlxDestroyUtil.destroyArray(list);
 		//_ui_control_callback = null;
 		callback = null;
 	}


### PR DESCRIPTION
Destroying a dropdown twice caused an error since list was null.