### PR TITLE
"implements IFlxUIButton" in FlxUITypedButton.hx

### DIFF
--- a/flixel/addons/ui/FlxUITypedButton.hx
+++ b/flixel/addons/ui/FlxUITypedButton.hx
@@ -24,7 +24,7 @@ import openfl.Assets;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 
 @:allow(FlxUITypedButton)
-class FlxUITypedButton<T:FlxSprite> extends FlxTypedButton<T> implements IResizable implements IFlxUIWidget implements IFlxUIClickable implements IHasParams implements ICursorPointable
+class FlxUITypedButton<T:FlxSprite> extends FlxTypedButton<T> implements IFlxUIButton implements IResizable implements IFlxUIWidget implements IFlxUIClickable implements IHasParams implements ICursorPointable
 {
 	public var name:String; 
 	public var resize_ratio:Float = -1;


### PR DESCRIPTION
FlxUITypedButton<T:FlxSprite> should declare it implements IFlxUIButton. For example this is needed to use this type of button in a FlxUIList.