### PR TITLE
FlxInputText: fix for last versions of Lime/OpenFL

### DIFF
--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -601,7 +601,7 @@ class FlxInputText extends FlxText
 			#if !js
 				textField.scrollH = diffW;
 			#end
-			calcFrame(true);
+			calcFrame();
 		}
 		#end
 	}


### PR DESCRIPTION
FlxInputText is not working on cpp as of OpenFL 3.4.0 and Lime 2.7.0. The first time the text is set works, but subsequent calls to `set_text` will not change the text the user sees.

This small change makes FlxInputText works again on cpp target. Also tested on Flash and HTML5, both working too.