### PR TITLE
Fixed cursor crash, closes #160

### DIFF
--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -429,7 +429,6 @@ class FlxUICursor extends FlxUISprite
 				return true;
 			}
 		}
-		location = -1;
 		return false;
 	}
 	
@@ -1164,7 +1163,6 @@ class FlxUICursor extends FlxUISprite
 		else	//move UP/DOWN
 		{
 			//Harder: iterate through array, looking for widget with higher or lower y value
-			
 			var nextY = _findNextY(Y, location, _widgets, null);
 			
 			if (nextY != -1)			//found something, just jump to that


### PR DESCRIPTION
I'm not really sure it's a proper fix to #160, but it works for my game at the very least. 

I noticed that if I never moved the mouse... the cursor worked fine with the keyboard. The problem was that _jumpToXY was setting location to -1 whenever the mouse moved but there was no control to focus and then when you pressed a key on the keyboard _findNextY tried to index the control array by location (-1), crashing the app of course.