### PR TITLE
Fixed 360 analog check crash, fixes #165

### DIFF
--- a/flixel/addons/ui/FlxMultiGamepadAnalogStick.hx
+++ b/flixel/addons/ui/FlxMultiGamepadAnalogStick.hx
@@ -48,6 +48,8 @@ class FlxMultiGamepadAnalogStick extends FlxMultiGamepad
 	
 	private override function checkJustPressed():Bool
 	{
+		if (gamepad == null) return false;
+
 		var value = false;
 		var dz = gamepad.deadZone;
 		return switch(sInput.id)


### PR DESCRIPTION
Trivial null-check to avoid crash reported in #165. It also seems to work fine once the gamepad actually connects and is detected.