### PR TITLE
fix html5 checkbox alignment

### DIFF
--- a/flixel/addons/ui/FlxUICheckBox.hx
+++ b/flixel/addons/ui/FlxUICheckBox.hx
@@ -97,6 +97,7 @@ class FlxUICheckBox extends FlxUIGroup implements ILabeled implements IFlxUIClic
 		
 		//set default checkbox label format
 		button.label.setFormat(null, 8, 0xffffff, "left", OUTLINE);
+                button.label.fieldWidth = LabelW;
 		button.up_color = 0xffffff;
 		button.down_color = 0xffffff;
 		button.over_color = 0xffffff;


### PR DESCRIPTION
On HTML5 checkbox labels are not positioned correctly, this fixes it on HTML5 and doesn't effect other targets.