### PR TITLE
Fix for wrong path on <sprite> src, closes #211

### DIFF
--- a/flixel/addons/ui/FlxUI.hx
+++ b/flixel/addons/ui/FlxUI.hx
@@ -4268,7 +4268,7 @@ class FlxUI extends FlxUIGroup implements IEventGetter
 				}
 				
 				var smooth = loadSmooth(data, true);
-				fs = new FlxUISprite(0, 0, U.loadScaledImage(src, W, H, smooth));
+				fs = new FlxUISprite(0, 0, U.loadScaledImage(U.xml_str(data.x, "src"), W, H, smooth));
 			}
 		}
 		else


### PR DESCRIPTION
See [issue #211](https://github.com/HaxeFlixel/flixel-ui/issues/211).