### PR TITLE
Fix FlxUICursor camera scroll

### DIFF
--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -325,6 +325,7 @@ class FlxUICursor extends FlxUISprite
 		{
 			var oldVis = visible;
 
+			// Ad hoc fix to avoid world coordinates on UI elements
 			if (scrollFactor.x == 0 && scrollFactor.y == 0)
 				jumpToXY(FlxG.mouse.screenX, FlxG.mouse.screenY);
 			else

--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -324,13 +324,15 @@ class FlxUICursor extends FlxUISprite
 		if (lastMouseX != FlxG.mouse.x || lastMouseY != FlxG.mouse.y)
 		{
 			var oldVis = visible;
-			jumpToXY(FlxG.mouse.x, FlxG.mouse.y);
+
+			if (scrollFactor.x == 0 && scrollFactor.y == 0)
+				jumpToXY(FlxG.mouse.screenX, FlxG.mouse.screenY);
+			else
+				jumpToXY(FlxG.mouse.x, FlxG.mouse.y);
 			visible = oldVis;
 
-			#if FLX_MOUSE
 			lastMouseX = FlxG.mouse.x;
 			lastMouseY = FlxG.mouse.y;
-			#end
 		}
 		#end
 


### PR DESCRIPTION
The UI cursor would not properly scroll with fixed UI elements, instead staying at the initialization position. There's also a redundant FLX_MOUSE check. Fixes #229