### PR TITLE
(WIP) `FlxUINumerixStepper` Make optional the minimum value when writing

### DIFF
--- a/flixel/addons/ui/FlxUINumericStepper.hx
+++ b/flixel/addons/ui/FlxUINumericStepper.hx
@@ -33,6 +33,10 @@ class FlxUINumericStepper extends FlxUIGroup implements IFlxUIWidget implements 
 
 	public var params(default, set):Array<Dynamic>;
 
+	//public var focusGained:Void->Void;
+	//public var focusLost:Void->Void;
+	public var hasFocus:Bool = false;
+
 	private function set_params(p:Array<Dynamic>):Array<Dynamic>
 	{
 		params = p;
@@ -213,6 +217,7 @@ class FlxUINumericStepper extends FlxUIGroup implements IFlxUIWidget implements 
 		TextField.y = 0;
 		text_field = TextField;
 		text_field.text = Std.string(DefaultValue);
+		text_field.focusLost = onFocusLost;
 
 		if ((text_field is FlxUIInputText))
 		{
@@ -264,6 +269,7 @@ class FlxUINumericStepper extends FlxUIGroup implements IFlxUIWidget implements 
 
 	private function _onInputTextEvent(text:String, action:String):Void
 	{
+		hasFocus = true;
 		if (text == "")
 		{
 			text = Std.string(min);


### PR DESCRIPTION
When editing, and let it with no values, it automatically change it to the minimum, and it normally makes it more difficult to use it, so I’m going to try to make it optional.