### PR TITLE
Add paste support for desktop and web + fix maxLength input

### DIFF
--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -229,7 +229,7 @@ class FlxInputText extends FlxText
 		}
 
 		lines = 1;
-		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
+		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown, false, 1);
 
 		if (Text == null)
 		{

--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -237,7 +237,7 @@ class FlxInputText extends FlxText
 		}
 
 		// Register paste events for the HTML5 parent window
-		#if (js && html5)
+		#if (html5 && js)
 		var window = Application.current.window;
 		@:privateAccess window.onTextInput.add(handleClipboardText);
 		#end
@@ -269,7 +269,7 @@ class FlxInputText extends FlxText
 		}
 		#end
 
-		#if (js && html5)
+		#if (html5 && js)
 		var window = Application.current.window;
 		@:privateAccess window.onTextInput.remove(handleClipboardText);
 		#end
@@ -387,7 +387,7 @@ class FlxInputText extends FlxText
 					onChange(ENTER_ACTION);
 				case V if (e.ctrlKey):
 					// Reapply focus  when tabbing back into the window and selecting the field
-					#if (js && html5)
+					#if (html5 && js)
 					var window = Application.current.window;
 					@:privateAccess window.textInputEnabled = true;
 					#else
@@ -850,7 +850,7 @@ class FlxInputText extends FlxText
 			calcFrame();
 
 			// Set focus on background parent text input
-			#if (js && html5)
+			#if (html5 && js)
 			var window = Application.current.window;
 			@:privateAccess window.__backend.setTextInputEnabled(newFocus);
 			#end

--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -15,7 +15,7 @@ import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxTimer;
 import lime.system.Clipboard;
 #if (html5 && js)
-import lime.app.Event;
+import lime.app.Application;
 #end
 
 /**

--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -15,7 +15,6 @@ import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxTimer;
 import lime.system.Clipboard;
 #if (html5 && js)
-import lime.app.Application;
 import lime.app.Event;
 #end
 

--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -431,7 +431,7 @@ class FlxInputText extends FlxText
 
 	function pasteClipboardText(clipboardText:String)
 	{
-		var newText = filter(clipboardText).substring(0, maxLength - text.length);
+		final newText = filter(clipboardText).substring(0, maxLength - text.length);
 
 		text = insertSubstring(text, newText, caretIndex);
 		caretIndex += newText.length;

--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -430,7 +430,7 @@ class FlxInputText extends FlxText
 
 	function pasteClipboardText(clipboardText:String)
 	{
-		final newText = filter(clipboardText).substring(0, maxLength - text.length);
+		final newText = filter(clipboardText).substring(0, maxLength > 0 ? (maxLength - text.length) : clipboardText.length);
 
 		text = insertSubstring(text, newText, caretIndex);
 		caretIndex += newText.length;


### PR DESCRIPTION
Add support for desktop and HTML5 javascript paste events by adding an event handler that fills the field as the parent text element changes. Fixes an issue with maxLength text entry. Closes #251.