### PR TITLE
Properly destroy `FlxUIList`

### DIFF
--- a/flixel/addons/ui/FlxUIList.hx
+++ b/flixel/addons/ui/FlxUIList.hx
@@ -6,6 +6,7 @@ import flixel.FlxObject;
 import flixel.FlxSprite;
 import flixel.ui.FlxButton;
 import flixel.math.FlxPoint;
+import flixel.util.FlxDestroyUtil;
 
 class FlxUIList extends FlxUIGroup
 {
@@ -184,12 +185,10 @@ class FlxUIList extends FlxUIGroup
 
 	public override function destroy():Void
 	{
-		prevButton = null;
-		nextButton = null;
-		prevButtonOffset.put();
-		nextButtonOffset.put();
-		prevButtonOffset = null;
-		nextButtonOffset = null;
+		prevButton = FlxDestroyUtil.destroy(prevButton);
+		nextButton = FlxDestroyUtil.destroy(nextButton);
+		prevButtonOffset = FlxDestroyUtil.put(prevButtonOffset);
+		nextButtonOffset = FlxDestroyUtil.put(nextButtonOffset);
 		super.destroy();
 	}
 


### PR DESCRIPTION
Fixes `prevButton` and `nextButton` not being destroyed if they're not added inside `FlxUIList`.
This also makes the button offset points put back to the pool using `FlxDestroyUtil`, preventing a crash if they're both already null.