### PR TITLE
fix _slice9 == []

### DIFF
--- a/flixel/addons/ui/FlxUI9SliceSprite.hx
+++ b/flixel/addons/ui/FlxUI9SliceSprite.hx
@@ -158,7 +158,7 @@ class FlxUI9SliceSprite extends FlxUISprite implements IResizable implements IFl
 		var iw = Std.int(pt.x);
 		var ih = Std.int(pt.y);
 
-		if (_slice9 == null || _slice9 == [])
+		if (_slice9 == null || _slice9.length != 4)
 		{
 			_slice9 = [4, 4, 7, 7];
 		}

--- a/flixel/addons/ui/FlxUI9SliceSprite.hx
+++ b/flixel/addons/ui/FlxUI9SliceSprite.hx
@@ -160,8 +160,8 @@ class FlxUI9SliceSprite extends FlxUISprite implements IResizable implements IFl
 
 		if (_slice9 == null || _slice9.length != 4)
 		{
-			if (_slice9.length != 4)
-				flixel.FlxG.log.warn("Invalid 9slice array!");
+			if (_slice9 != null)
+				flixel.FlxG.log.warn("Invalid 9slice array, expected a length of 4");
 			_slice9 = [4, 4, 7, 7];
 		}
 

--- a/flixel/addons/ui/FlxUI9SliceSprite.hx
+++ b/flixel/addons/ui/FlxUI9SliceSprite.hx
@@ -160,6 +160,8 @@ class FlxUI9SliceSprite extends FlxUISprite implements IResizable implements IFl
 
 		if (_slice9 == null || _slice9.length != 4)
 		{
+			if (_slice9.length != 4)
+				flixel.FlxG.log.warn("Invalid 9slice array!");
 			_slice9 = [4, 4, 7, 7];
 		}
 


### PR DESCRIPTION
`[] == []` is `false`, because arrays
i simply changed `_slice9 == []` to `_slice9.length != 4` (in FlxUI9SliceSprite, line 161) which would achieve the intended purpose, i think