### PR TITLE
Return scaled center coordinates for widgets

### DIFF
--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -926,8 +926,8 @@ class FlxUICursor extends FlxUISprite
 		}
 
 		// get center point of object
-		widgetPoint.x += currWidget.width / 2;
-		widgetPoint.y += currWidget.height / 2;
+		widgetPoint.x += currWidget.width * Camera.totalScaleX * 0.5;
+		widgetPoint.y += currWidget.height * Camera.totalScaleY * 0.5;
 
 		return widgetPoint;
 	}


### PR DESCRIPTION
The button width / height always return the center values of the native button. At larger scale modes, the disparity grows enough that other buttons can sometimes be pressed when overlapping each other because it doesn't return the actual center coordinates.