### PR TITLE
Fix for incorrect handling of `CLICK_EVENT` in FlxUIPopup

### DIFF
--- a/flixel/addons/ui/FlxUIPopup.hx
+++ b/flixel/addons/ui/FlxUIPopup.hx
@@ -188,29 +188,20 @@ class FlxUIPopup extends FlxUISubState implements IFlxUIWidget
 		switch (id)
 		{
 			case FlxUITypedButton.CLICK_EVENT:
-				var str = "";
 				if (eventParams != null)
 				{
-					if ((eventParams[0] is String))
-					{
-						str = Std.string(eventParams[0]);
-					}
-
 					var buttonAmount:Int = Std.int(eventParams[0]);
-					if (str == "affirm" || str == "cancel" || str == "alt")
+					if ((_parentState is IFlxUIState))
 					{
-						if ((_parentState is IFlxUIState))
-						{
-							// This fixes a bug where the event was being sent to this popup rather than the state that created it
-							castParent().getEvent(CLICK_EVENT, this, buttonAmount, eventParams);
-						}
-						else
-						{
-							// This is a generic fallback in case something goes wrong
-							FlxUI.event(CLICK_EVENT, this, buttonAmount, eventParams);
-						}
-						close();
+						// This fixes a bug where the event was being sent to this popup rather than the state that created it
+						castParent().getEvent(CLICK_EVENT, this, buttonAmount, eventParams);
 					}
+					else
+					{
+						// This is a generic fallback in case something goes wrong
+						FlxUI.event(CLICK_EVENT, this, buttonAmount, eventParams);
+					}
+					close();
 				}
 		}
 		super.getEvent(id, sender, data, eventParams);


### PR DESCRIPTION
It looks like FlxUIPopup was expecting one of the event paramters in `getEvent` to be either "affirm", "cancel" or "alt" but that never happens (even the default_popup.xml file never mentions "affirm", "cancel" or "alt" https://github.com/HaxeFlixel/flixel-ui/blob/dev/assets/xml/default_popup.xml ). This should remove references to that and only use the `buttonAmount` parameter when handling click events for FlxUIPopup. This should also fix HaxeFlixel/flixel-demos#267