### PR TITLE
Support Android browser text input

### DIFF
--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -243,6 +243,7 @@ class FlxInputText extends FlxText
 	override public function destroy():Void
 	{
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
+		FlxG.stage.window.onTextInput.remove(windowInputText);
 
 		backgroundSprite = FlxDestroyUtil.destroy(backgroundSprite);
 		fieldBorderSprite = FlxDestroyUtil.destroy(fieldBorderSprite);

--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -330,7 +330,7 @@ class FlxInputText extends FlxText
 			var hadFocus:Bool = hasFocus;
 			if (FlxG.touches.getFirst().overlaps(this))
 			{
-				caretIndex = getCaretIndex();
+				caretIndex = getCaretIndex(false);
 				hasFocus = true;
 				if (!hadFocus && focusGained != null)
 					focusGained();
@@ -435,21 +435,30 @@ class FlxInputText extends FlxText
 	}
 
 	/**
-	 * Gets the index of the character in this box under the mouse cursor
+	 * Gets the index of the character in this box under the mouse cursor or touch event
 	 * @return The index of the character.
 	 *         between 0 and the length of the text
 	 */
-	private function getCaretIndex():Int
+	private function getCaretIndex(isMouse:Bool = true):Int
 	{
-		#if FLX_MOUSE
-		var hit = FlxPoint.get(FlxG.mouse.x - x, FlxG.mouse.y - y);
-		return getCharIndexAtPoint(hit.x, hit.y);
-		#elseif FLX_TOUCH
-		var hit = FlxPoint.get(FlxG.touches.getFirst().x - x, FlxG.touches.getFirst().y - y);
-		return getCharIndexAtPoint(hit.x, hit.y);
-		#else
-		return 0;
-		#end
+		if(isMouse)
+		{
+			#if FLX_MOUSE
+			var hit = FlxPoint.get(FlxG.mouse.x - x, FlxG.mouse.y - y);
+			return getCharIndexAtPoint(hit.x, hit.y);
+			#else
+			return 0;
+			#end
+		}
+		else
+		{
+			#if FLX_TOUCH
+			var hit = FlxPoint.get(FlxG.touches.getFirst().x - x, FlxG.touches.getFirst().y - y);
+			return getCharIndexAtPoint(hit.x, hit.y);
+			#else
+			return 0;
+			#end
+		}
 	}
 
 	private function getCharBoundaries(charIndex:Int):Rectangle


### PR DESCRIPTION
Some Android browsers can not type in text input fields. I leveraged `window.onTextInput` to detect text changes and refactored code to remove redundancies and improve performance. Some mobile targets also require touch detection. Fixes #262.

I've tested typing and pasting text on desktop, mobile and web (both GeckoView and WebView browsers). These changes are also working with the latest versions of OpenFL and Lime.