### PR TITLE
FlxUICursor: prevent/remove references to disconnected gamepads

### DIFF
--- a/flixel/addons/ui/FlxMultiGamepad.hx
+++ b/flixel/addons/ui/FlxMultiGamepad.hx
@@ -28,36 +28,26 @@ class FlxMultiGamepad extends FlxBaseMultiInput
 
 	private override function checkJustPressed():Bool
 	{
-		if (gamepad == null)
-			return false;
 		return gamepad.checkStatus(input, JUST_PRESSED);
 	}
 
 	private override function checkJustReleased():Bool
 	{
-		if (gamepad == null)
-			return false;
 		return gamepad.checkStatus(input, JUST_RELEASED);
 	}
 
 	private override function checkPressed():Bool
 	{
-		if (gamepad == null)
-			return false;
 		return gamepad.checkStatus(input, PRESSED);
 	}
 
 	private override function checkCombos(value:Bool):Bool
 	{
-		if (gamepad == null)
-			return false;
 		return gamepad.anyPressed(combos) == value;
 	}
 
 	private override function checkForbiddens(value:Bool):Bool
 	{
-		if (gamepad == null)
-			return false;
 		return gamepad.anyPressed(forbiddens) == value;
 	}
 }

--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -311,7 +311,12 @@ class FlxUICursor extends FlxUISprite
 	{
 		#if FLX_GAMEPAD
 		if (gamepad == null || !gamepad.connected)
-			gamepad = getGamepad(false);
+		{
+			final g = getGamepad(false);
+			// avoid calling set_gamepad unnecessarily 
+			if (gamepad != g)
+				gamepad = g;
+		}
 		#end
 
 		#if FLX_MOUSE

--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -310,14 +310,8 @@ class FlxUICursor extends FlxUISprite
 	public override function update(elapsed:Float):Void
 	{
 		#if FLX_GAMEPAD
-		if (gamepad == null)
-		{
-			var g = getGamepad(false);
-			if (g != null)
-			{
-				gamepad = g;
-			}
-		}
+		if (gamepad == null || !gamepad.connected)
+			gamepad = getGamepad(false);
 		#end
 
 		#if FLX_MOUSE
@@ -692,25 +686,24 @@ class FlxUICursor extends FlxUISprite
 	#if FLX_GAMEPAD
 	private function getGamepad(exhaustive:Bool = true):FlxGamepad
 	{
-		var gamepad = switch (gamepadAutoConnect)
+		final gamepad = switch (gamepadAutoConnect)
 		{
 			case Never: null;
 			case FirstActive: FlxG.gamepads.getFirstActiveGamepad();
 			case LastActive: FlxG.gamepads.lastActive;
 			case GamepadID(i): FlxG.gamepads.getByID(i);
 		}
-		if (gamepad == null && exhaustive)
+
+		if ((gamepad != null && gamepad.connected) || !exhaustive)
+			return gamepad;
+
+		for (i in 0...FlxG.gamepads.numActiveGamepads)
 		{
-			for (i in 0...FlxG.gamepads.numActiveGamepads)
-			{
-				gamepad = FlxG.gamepads.getByID(i);
-				if (gamepad != null)
-				{
-					return gamepad;
-				}
-			}
+			final gamepad = FlxG.gamepads.getByID(i);
+			if (gamepad != null && gamepad.connected)
+				return gamepad;
 		}
-		return gamepad;
+		return null;
 	}
 	#end
 

--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -606,12 +606,14 @@ class FlxUICursor extends FlxUISprite
 		_defaultCode = code;
 		_clearKeys();
 		_newKeys();
+		
 		if (code.has(KEYS_TAB))
 		{
 			_addToKeys(keysRight, new FlxMultiKey(TAB, null, [SHIFT])); // Tab, (but NOT Shift+Tab!)
 			_addToKeys(keysLeft, new FlxMultiKey(TAB, [SHIFT])); // Shift+Tab
 			_addToKeys(keysClick, new FlxMultiKey(ENTER));
 		}
+		
 		if (code.has(KEYS_ARROWS))
 		{
 			_addToKeys(keysRight, new FlxMultiKey(RIGHT));
@@ -620,6 +622,7 @@ class FlxUICursor extends FlxUISprite
 			_addToKeys(keysUp, new FlxMultiKey(UP));
 			_addToKeys(keysClick, new FlxMultiKey(ENTER));
 		}
+		
 		if (code.has(KEYS_WASD))
 		{
 			_addToKeys(keysRight, new FlxMultiKey(D));
@@ -628,6 +631,7 @@ class FlxUICursor extends FlxUISprite
 			_addToKeys(keysUp, new FlxMultiKey(W));
 			_addToKeys(keysClick, new FlxMultiKey(ENTER));
 		}
+		
 		if (code.has(KEYS_NUMPAD))
 		{
 			_addToKeys(keysRight, new FlxMultiKey(NUMPADSIX));
@@ -636,42 +640,46 @@ class FlxUICursor extends FlxUISprite
 			_addToKeys(keysUp, new FlxMultiKey(NUMPADEIGHT));
 			_addToKeys(keysClick, new FlxMultiKey(ENTER));
 		}
-
+		
 		#if FLX_GAMEPAD
-		if (gamepad == null)
-		{
+		if (_gamepad == null || !_gamepad.connected)
 			_gamepad = getGamepad(); // set _gamepad to avoid a stack overflow loop
-		}
-
-		if (code.has(GAMEPAD_DPAD))
+		
+		if (_gamepad != null && _gamepad.connected)
 		{
-			_addToKeys(keysLeft, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_LEFT));
-			_addToKeys(keysRight, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_RIGHT));
-			_addToKeys(keysDown, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_DOWN));
-			_addToKeys(keysUp, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_UP));
-			_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
-		}
-		if (code.has(GAMEPAD_SHOULDER_BUTTONS))
-		{
-			_addToKeys(keysLeft, new FlxMultiGamepad(gamepad, FlxGamepadInputID.LEFT_SHOULDER));
-			_addToKeys(keysRight, new FlxMultiGamepad(gamepad, FlxGamepadInputID.RIGHT_SHOULDER));
-			_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
-		}
-		if (code.has(GAMEPAD_LEFT_STICK))
-		{
-			_addToKeys(keysLeft, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: X, positive: false}));
-			_addToKeys(keysRight, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: X, positive: true}));
-			_addToKeys(keysUp, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: Y, positive: false}));
-			_addToKeys(keysDown, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: Y, positive: true}));
-			_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
-		}
-		if (code.has(GAMEPAD_RIGHT_STICK))
-		{
-			_addToKeys(keysLeft, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: X, positive: false}));
-			_addToKeys(keysRight, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: X, positive: true}));
-			_addToKeys(keysUp, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: Y, positive: false}));
-			_addToKeys(keysDown, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: Y, positive: true}));
-			_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
+			if (code.has(GAMEPAD_DPAD))
+			{
+				_addToKeys(keysLeft, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_LEFT));
+				_addToKeys(keysRight, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_RIGHT));
+				_addToKeys(keysDown, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_DOWN));
+				_addToKeys(keysUp, new FlxMultiGamepad(gamepad, FlxGamepadInputID.DPAD_UP));
+				_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
+			}
+			
+			if (code.has(GAMEPAD_SHOULDER_BUTTONS))
+			{
+				_addToKeys(keysLeft, new FlxMultiGamepad(gamepad, FlxGamepadInputID.LEFT_SHOULDER));
+				_addToKeys(keysRight, new FlxMultiGamepad(gamepad, FlxGamepadInputID.RIGHT_SHOULDER));
+				_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
+			}
+			
+			if (code.has(GAMEPAD_LEFT_STICK))
+			{
+				_addToKeys(keysLeft, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: X, positive: false}));
+				_addToKeys(keysRight, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: X, positive: true}));
+				_addToKeys(keysUp, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: Y, positive: false}));
+				_addToKeys(keysDown, new FlxMultiGamepadAnalogStick(gamepad, {id: LEFT_ANALOG_STICK, axis: Y, positive: true}));
+				_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
+			}
+			
+			if (code.has(GAMEPAD_RIGHT_STICK))
+			{
+				_addToKeys(keysLeft, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: X, positive: false}));
+				_addToKeys(keysRight, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: X, positive: true}));
+				_addToKeys(keysUp, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: Y, positive: false}));
+				_addToKeys(keysDown, new FlxMultiGamepadAnalogStick(gamepad, {id: RIGHT_ANALOG_STICK, axis: Y, positive: true}));
+				_addToKeys(keysClick, new FlxMultiGamepad(gamepad, FlxGamepadInputID.A));
+			}
 		}
 		#end
 	}


### PR DESCRIPTION
FlxUICursor is oddly written, when there's no gamepads it adds gamepad listeners with a null gamepad, then checks for null gamepads every frame for dozens of inputs. this change will simply not add useless button listeners unless theres a connected gamepad. It also checks whether the current gamepad is disconnected, and removes listeners when that gamepad is disconnected, fixing https://github.com/HaxeFlixel/flixel/pull/2991

@DigiEggz please try this out, or lmk if you don't have time