### PR TITLE
Remove identifier ambiguity (fixes Potential Typo warning).

### DIFF
--- a/flixel/addons/ui/FlxUICursor.hx
+++ b/flixel/addons/ui/FlxUICursor.hx
@@ -559,9 +559,9 @@ class FlxUICursor extends FlxUISprite
 		}
 		switch (method)
 		{
-			case XY:
+			case SortMethod.XY:
 				list.sort(_sortXYVisible);
-			case ID:
+			case SortMethod.ID:
 				list.sort(_sortIDVisible);
 		}
 	}


### PR DESCRIPTION
This has driven me insane for more than a year here's the fix.