### PR TITLE
prevent premature closing when selecting items

### DIFF
--- a/flixel/addons/ui/FlxUIDropDownMenu.hx
+++ b/flixel/addons/ui/FlxUIDropDownMenu.hx
@@ -405,17 +405,30 @@ class FlxUIDropDownMenu extends FlxUIGroup implements IFlxUIWidget implements IF
 	public override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
-
+		
 		#if FLX_MOUSE
-		if (dropPanel.visible && FlxG.mouse.justPressed)
-		{
-			if (!FlxG.mouse.overlaps(this))
-			{
-				showList(false);
-			}
-		}
+		checkClickOff();
 		#end
 	}
+	
+	#if FLX_MOUSE
+	function checkClickOff()
+	{
+		if (dropPanel.visible && FlxG.mouse.justPressed)
+		{
+			if (header.button.justPressed)
+				return;
+			
+			for (button in list)
+			{
+				if (button.justPressed)
+					return;
+			}
+			
+			showList(false);
+		}
+	}
+	#end
 
 	override public function destroy():Void
 	{


### PR DESCRIPTION
FIxes https://github.com/HaxeFlixel/flixel-ui/issues/274

clicking a dropdown items seemed to first trigger a collapse before it would have selected the item you clicked

Fix proposed by @gamerbross