### PR TITLE
fix: FlxUICheckBox returning always checked=false in event params

### DIFF
--- a/flixel/addons/ui/FlxUICheckBox.hx
+++ b/flixel/addons/ui/FlxUICheckBox.hx
@@ -54,7 +54,7 @@ class FlxUICheckBox extends FlxUIGroup implements ILabeled implements IFlxUIClic
 		{
 			params = [];
 		}
-		var nb:NamedBool = {name: "checked", value: false};
+		var nb:NamedBool = {name: "checked", value: checked};
 		params.push(nb);
 		return params;
 	}


### PR DESCRIPTION
FlxUICheckBox is documented to have a `checked` param in its click event that contains the new state of the checkbox. 
However, when the format of the param was changed from `String` to `NamedBool` there was added a regression that would make the parameter to always be false and not the actual state of the checkbox.
