### PR TITLE
Remove refs to statusAnimations for flixel > 5.9

### DIFF
--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -745,7 +745,7 @@ class FlxInputText extends FlxText
 					r.x = r.y = 0;
 					caret.pixels.fillRect(r, caretC); // draw caret
 					caret.offset.x = caret.offset.y = 0;
-				#if (flixel > "5.8.0")
+				#if (flixel > version("5.8.0"))
 				case SHADOW_XY(shadowX, shadowY):
 					// Shadow offset to the lower-right
 					cw += Std.int(Math.abs(shadowX));

--- a/flixel/addons/ui/FlxUIGroup.hx
+++ b/flixel/addons/ui/FlxUIGroup.hx
@@ -4,11 +4,11 @@ import flixel.FlxSprite;
 import flixel.group.FlxSpriteGroup;
 import flixel.math.FlxRect;
 import flixel.addons.ui.interfaces.IFlxUIWidget;
-#if (flixel >= "5.7.0")
+#if (flixel >= version("5.7.0"))
 import flixel.group.FlxSpriteContainer;
 #end
 
-#if (flixel < "5.4.0" && FLX_NO_POINT_POOL)
+#if (flixel < version("5.4.0") && FLX_NO_POINT_POOL)
 	/* This is a weird haxe bug I haven't figured out, fixed in 5.4.0
 	 * via https://github.com/HaxeFlixel/flixel/pull/2808
 	 * Note: this is only the case when FLX_NO_POINT_POOL is defined.

--- a/flixel/addons/ui/FlxUITypedButton.hx
+++ b/flixel/addons/ui/FlxUITypedButton.hx
@@ -179,9 +179,9 @@ class FlxUITypedButton<T:FlxSprite> extends FlxTypedButton<T> implements IFlxUIB
 	{
 		super.graphicLoaded();
 		
-		setupAnimation(getToggleStatusAnimation(NORMAL, 3));
-		setupAnimation(getToggleStatusAnimation(HIGHLIGHT, #if FLX_MOUSE 4 #else 3 #end));
-		setupAnimation(getToggleStatusAnimation(PRESSED, 5));
+		setupAnimation(getToggleStatusAnimation(NORMAL), 3);
+		setupAnimation(getToggleStatusAnimation(HIGHLIGHT), #if FLX_MOUSE 4 #else 3 #end);
+		setupAnimation(getToggleStatusAnimation(PRESSED), 5);
 
 		if (_autoCleanup)
 		{

--- a/flixel/addons/ui/FlxUITypedButton.hx
+++ b/flixel/addons/ui/FlxUITypedButton.hx
@@ -170,27 +170,38 @@ class FlxUITypedButton<T:FlxSprite> extends FlxTypedButton<T> implements IFlxUIB
 
 		_centerLabelOffset = FlxPoint.get(0, 0);
 
-		statusAnimations[3] = "normal_toggled";
-		statusAnimations[4] = "highlight_toggled";
-		statusAnimations[5] = "pressed_toggled";
-
 		labelAlphas = [for (i in 0...3) 1];
 
 		inputOver = new FlxInput(0);
 	}
-
+	
 	override public function graphicLoaded():Void
 	{
 		super.graphicLoaded();
-
-		setupAnimation("normal_toggled", 3);
-		setupAnimation("highlight_toggled", 4);
-		setupAnimation("pressed_toggled", 5);
+		
+		setupAnimation(getToggleStatusAnimation(NORMAL, 3));
+		setupAnimation(getToggleStatusAnimation(HIGHLIGHT, #if FLX_MOUSE 4 #else 3 #end));
+		setupAnimation(getToggleStatusAnimation(PRESSED, 5));
 
 		if (_autoCleanup)
 		{
 			cleanup();
 		}
+	}
+	
+	function getToggleStatusAnimation(status:FlxButtonState)
+	{
+		#if (flixel <= "5.9.0")
+		return switch(status)
+		{
+			case NORMAL: "normal_toggled";
+			case PRESSED: "pressed_toggled";
+			case HIGHLIGHT: "highlight_toggled";
+			case DISABLED: "disabled_toggled";
+		}
+		#else
+		return status.toString() + "_toggled";
+		#end
 	}
 
 	@:access(flixel.addons.ui.FlxUITypedButton)
@@ -311,14 +322,11 @@ class FlxUITypedButton<T:FlxSprite> extends FlxTypedButton<T> implements IFlxUIB
 		}
 	}
 
-	/**
-	 * Offset the statusAnimations-index by 3 when toggled.
-	 */
-	override public function updateStatusAnimation():Void
+	override function updateStatusAnimation():Void
 	{
 		if (has_toggle && toggled)
 		{
-			animation.play(statusAnimations[status + 3]);
+			animation.play(getToggleStatusAnimation(status));
 		}
 		else
 		{

--- a/flixel/addons/ui/FontDef.hx
+++ b/flixel/addons/ui/FontDef.hx
@@ -7,7 +7,7 @@ import flixel.text.FlxText;
 import flixel.util.FlxColor;
 import openfl.Assets;
 import openfl.text.TextFormatAlign;
-#if (openfl >= "4.0.0")
+#if (openfl >= version("4.0.0"))
 import openfl.utils.AssetType;
 #end
 

--- a/flixel/addons/ui/FontFixer.hx
+++ b/flixel/addons/ui/FontFixer.hx
@@ -1,7 +1,7 @@
 package flixel.addons.ui;
 
 import openfl.Assets;
-#if (openfl >= "4.0.0")
+#if (openfl >= version("4.0.0"))
 import openfl.utils.AssetType;
 #end
 

--- a/flixel/addons/ui/U.hx
+++ b/flixel/addons/ui/U.hx
@@ -27,7 +27,7 @@ import sys.FileSystem;
 import sys.io.File;
 import sys.io.FileOutput;
 #end
-#if (openfl >= "4.0.0")
+#if (openfl >= version("4.0.0"))
 import openfl.utils.AssetType;
 #end
 #if haxe4


### PR DESCRIPTION
backwards compatible

For https://github.com/HaxeFlixel/flixel/pull/3340
status animations isn't needed now that status.toString() exists, and it was a weird system to begin with