### PR TITLE
Fix FlxUITypedButton.hx Compatibility

### DIFF
--- a/flixel/addons/ui/FlxUITypedButton.hx
+++ b/flixel/addons/ui/FlxUITypedButton.hx
@@ -24,7 +24,7 @@ import openfl.display.BitmapData;
 import openfl.errors.Error;
 
 #if (flixel < version("5.7.0"))
-enum abstract FlxButtonState(Int) to Int
+enum abstract FlxButtonState(Int) from Int to Int
 {
 	var NORMAL = 0;
 	var HIGHLIGHT = 1;


### PR DESCRIPTION
Fixes compatibility for versions below flixel 5.7.0

`flixel.ui.FlxButton` status variable used to be an integer and `enum flixel.addons.ui.FlxUITypedButton.FlxButtonState` doesnt accept int, which makes an error.