### PR TITLE
FlxInputText: Fix compatibility with flixel versions < 5.7.0

### DIFF
--- a/flixel/addons/ui/FlxInputText.hx
+++ b/flixel/addons/ui/FlxInputText.hx
@@ -288,7 +288,8 @@ class FlxInputText extends FlxText
 		drawSprite(fieldBorderSprite);
 		drawSprite(backgroundSprite);
 		
-		for (camera in getCamerasLegacy())
+		final defaultCameras = #if (flixel < version("5.7.0")) cameras #else getCamerasLegacy() #end;
+		for (camera in defaultCameras)
 		{
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;

--- a/flixel/addons/ui/FlxUITypedButton.hx
+++ b/flixel/addons/ui/FlxUITypedButton.hx
@@ -326,7 +326,11 @@ class FlxUITypedButton<T:FlxSprite> extends FlxTypedButton<T> implements IFlxUIB
 	{
 		if (has_toggle && toggled)
 		{
+			#if (flixel < version("5.7.0"))
+			animation.play(getToggleStatusAnimation((cast status:FlxButtonState)));
+			#else
 			animation.play(getToggleStatusAnimation(status));
+			#end
 		}
 		else
 		{


### PR DESCRIPTION
Alternative to https://github.com/HaxeFlixel/flixel-ui/pull/296

Removes ref to getCamerasLegacy() and casts FlxTypedButton.status from an int
