### PR TITLE
IFlxUIWidget: Remove refs to IFlxSprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.6.5 (June 13, 2026)
+------------------------------
+`FlxUIRegion`: Fix Deprecation warning ([#294](https://github.com/HaxeFlixel/flixelui/pull/294))
+`FlxInputText`: Fix compatibility with flixel versions < 5.7.0 ([#297](https://github.com/HaxeFlixel/flixelui/pull/297))
+Turkish translation of Readme ([#299](https://github.com/HaxeFlixel/flixelui/pull/299))
+Deprecate `FlxInputText` (No PR)
+
+
 2.6.4 (December 10, 2024)
 ------------------------------
 `FlxUITypedButton`: Avoid deprecated `statusAnimations` field ([#291](https://github.com/HaxeFlixel/flixel-ui/pull/291))

--- a/flixel/addons/ui/interfaces/IFlxUIWidget.hx
+++ b/flixel/addons/ui/interfaces/IFlxUIWidget.hx
@@ -1,20 +1,58 @@
 package flixel.addons.ui.interfaces;
 
-import flixel.addons.ui.FlxUI.UIEventCallback;
-import flixel.FlxSprite;
+import flixel.math.FlxPoint;
+import flixel.util.FlxDirectionFlags;
 
 /**
  * ...
  * @author Lars Doucet
  */
-interface IFlxUIWidget extends IFlxSprite
+interface IFlxUIWidget
 {
-	public var name:String;
-	public var width(get, set):Float;
-	public var height(get, set):Float;
+	// IFlxUIWidget
+	var name:String;
+	var width(get, set):Float;
+	var height(get, set):Float;
 
 	/**
 	 * If true, will issue FlxUI.event() and FlxUI.request() calls
 	 */
-	public var broadcastToFlxUI:Bool;
+	var broadcastToFlxUI:Bool;
+	
+	// FlxSprite
+	var x(default, set):Float;
+	var y(default, set):Float;
+	var alpha(default, set):Float;
+	var angle(default, set):Float;
+	var facing(default, set):FlxDirectionFlags;
+	var moves(default, set):Bool;
+	var immovable(default, set):Bool;
+
+	var offset(default, null):FlxPoint;
+	var origin(default, null):FlxPoint;
+	var scale(default, null):FlxPoint;
+	var velocity(default, null):FlxPoint;
+	var maxVelocity(default, null):FlxPoint;
+	var acceleration(default, null):FlxPoint;
+	var drag(default, null):FlxPoint;
+	var scrollFactor(default, null):FlxPoint;
+
+	function reset(X:Float, Y:Float):Void;
+	function setPosition(X:Float = 0, Y:Float = 0):Void;
+	
+	// FlxBasic
+	var ID:Int;
+	var active(default, set):Bool;
+	var visible(default, set):Bool;
+	var alive(default, set):Bool;
+	var exists(default, set):Bool;
+
+	function draw():Void;
+	function update(elapsed:Float):Void;
+	function destroy():Void;
+
+	function kill():Void;
+	function revive():Void;
+
+	function toString():String;
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"tags": ["game", "openfl", "flash", "neko", "cpp", "android", "ios", "cross"],
 	"description": "A UI library for Flixel",
-	"version": "2.6.4",
-	"releasenote": "Compatibility with Flixel 6.0.0",
+	"version": "2.6.5",
+	"releasenote": "Deprecate FlxInputText",
 	"contributors": ["haxeflixel", "larsiusprime", "Gama11", "GeoKureli"]
 }


### PR DESCRIPTION
Made in tandem with https://github.com/HaxeFlixel/flixel/pull/3598

There shouldn't be any versioning issues with old flixel versions, or vice versa, except people using older flixel-ui versions will have deprecation warnings. 